### PR TITLE
update swagger UI styles

### DIFF
--- a/packages/fets/src/swagger-ui.html
+++ b/packages/fets/src/swagger-ui.html
@@ -6,7 +6,7 @@
     <meta name="description" content="SwaggerUI" />
     <title>SwaggerUI</title>
     <style>
-      @import 'https://cdn.jsdelivr.net/gh/Itz-fork/Fastapi-Swagger-UI-Dark/assets/swagger_ui_dark.min.css'
+      @import 'https://raw.githubusercontent.com/Itz-fork/Fastapi-Swagger-UI-Dark/main/assets/swagger_ui_dark.min.css'
         (prefers-color-scheme: dark);
 
       @import 'https://unpkg.com/swagger-ui-dist/swagger-ui.css' (prefers-color-scheme: light);


### PR DESCRIPTION
## Description

Update the URL for the stylesheet used in the auto-generated swagger UI because jsdeliver is blocked in some countries.

Related #436 


## Type of change

Bug fix (non-breaking change which fixes an issue)