### PR TITLE
fix(client): improve support of deepObject query serialization method

### DIFF
--- a/packages/fets/src/client/createClient.ts
+++ b/packages/fets/src/client/createClient.ts
@@ -105,6 +105,11 @@ export function createClient({ endpoint, fetchFn = fetch, plugins = [] }: Client
                     for (const v of value) {
                       searchParams.append(queryParamKey, v);
                     }
+                  } else if (typeof value === 'object' && value !== null) {
+                    // @see https://swagger.io/docs/specification/serialization/#query
+                    for (const v of Object.keys(value)) {
+                      searchParams.append(`${queryParamKey}[${v}]`, value[v]);
+                    }
                   } else {
                     searchParams.append(queryParamKey, value);
                   }

--- a/packages/fets/tests/client-query-serialization.spec.ts
+++ b/packages/fets/tests/client-query-serialization.spec.ts
@@ -1,0 +1,30 @@
+import {
+  createClient,
+  type NormalizeOAS,
+} from 'fets';
+import type clientQuerySerializationOAS from './fixtures/example-client-query-serialization-oas';
+
+type NormalizedOAS = NormalizeOAS<typeof clientQuerySerializationOAS>;
+
+describe('Client', () => {
+  it('should support deep objects in query', async () => {
+    const client = createClient<NormalizedOAS>({
+      endpoint: 'https://postman-echo.com'
+    });
+
+    const response = await client['/get'].get({
+        query: {
+          shallow: 'foo',
+          deep: {
+            key1: 'bar',
+            key2: 'baz',
+          },
+          array: ['qux', 'quux']
+        },
+      });
+  
+      const json = await response.json();
+
+      expect(json.url).toBe('https://postman-echo.com/get?shallow=foo&deep%5Bkey1%5D=bar&deep%5Bkey2%5D=baz&array=qux%2Cquux');
+  })
+});

--- a/packages/fets/tests/fixtures/example-client-query-serialization-oas.ts
+++ b/packages/fets/tests/fixtures/example-client-query-serialization-oas.ts
@@ -1,0 +1,77 @@
+/* eslint-disable */
+export default {
+  openapi: '3.0.3',
+  servers: ['https://postman-echo.com'],
+  paths: {
+    '/get': {
+      get: {
+        summary: 'GET Request',
+        description: '',
+        operationId: 'GetGet',
+        deprecated: 0,
+        parameters: [
+          {
+            name: 'shallow',
+            in: 'query',
+            description: '',
+            schema: {
+              type: 'string',
+              required: false,
+            }
+          },
+          {
+            name: 'deep',
+            in: 'query',
+            description: '',
+            schema: {
+              type: 'object',
+              properties: {
+                key1: {
+                  type: 'string',
+                  example: 'bar',
+                },
+                key2: {
+                  type: 'string',
+                  example: 'baz',
+                },
+              },
+            },
+            style: 'deepObject',
+            explode: true,
+            required: false,
+          },
+          {
+            name: 'array',
+            in: 'query',
+            description: '',
+            schema: {
+              type: 'array',
+              items: {
+                type: 'string',
+              },
+            },
+            required: false,
+          }
+        ],
+        responses: {
+          '200': {
+            description: '',
+            content: {
+              'application/json; charset=utf-8': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    url: {
+                      type: 'string',
+                      description: '',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+} as const;


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on WhatWG Node!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of
the pull request._

## Description

Client - Deep objects are sent as empty string in query parameters.  
This makes the client unsuitable for use with [JSON:API sparse fieldsets](https://jsonapi.org/format/#fetching-sparse-fieldsets)

Related #516

## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can
reproduce. Please also list any relevant details for your test configuration

- [x] yarn test packages/fets/tests/client-query-serialization.spec.ts

Running the test will perform a query to https://postman-echo.com/ to assert that the request sent by the client contains the expected query parameters.

**Test Environment**:

- OS: macOS
- `package-name`: fets
- NodeJS: no

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
  -> No changeset generated yet
- [ ] My changes generate no new warnings
  -> GitHub Codespaces shows a linting error in my test file, I don't now why
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
  -> I am not aware of any downstream module which would be affected by this

## Further comments

This change, albeit small, is a breaking change: people who would expect objects to be stripped from the query parameters sent by the client will now see them sent to the server. I won't probably cause any issue, but…
