### PR TITLE
Fix json field type for POST requests

### DIFF
--- a/.changeset/weak-mugs-act.md
+++ b/.changeset/weak-mugs-act.md
@@ -1,0 +1,5 @@
+---
+'fets': patch
+---
+
+Fix json field typing for client POST requests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ permissions: write-all
 
 jobs:
   stable:
+    if: github.event.pull_request.head.repo.full_name == github.repository
     uses: the-guild-org/shared-config/.github/workflows/release-stable.yml@main
     with:
       releaseScript: release

--- a/examples/spotify/index.ts
+++ b/examples/spotify/index.ts
@@ -52,6 +52,25 @@ export async function getRecommendations(token: string, artistId: string, trackI
   return data;
 }
 
+export async function createPlaylist(token: string, userId: string, name: string) {
+  const res = await client['/users/{user_id}/playlists'].post({
+    json: {
+      name,
+    },
+    params: {
+      user_id: userId,
+    },
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+  if (!res.ok) {
+    const errData = await res.json();
+    throw new Error(errData.error.message);
+  }
+  return res.json();
+}
+
 async function main() {
   const token = await getToken();
   const res = await client['/search'].get({

--- a/packages/fets/src/client/types.ts
+++ b/packages/fets/src/client/types.ts
@@ -254,7 +254,7 @@ type FixAdditionalPropertiesForAllOf<T> = T extends { allOf: any[] }
 type FixMissingTypeObject<T> = T extends { properties: any } ? T & { type: 'object' } : T;
 
 type FixMissingAdditionalProperties<T> = T extends { type: 'object'; properties: any }
-  ? T & { additionalProperties: false }
+  ? Omit<T, 'additionalProperties'> & { additionalProperties: false }
   : T;
 
 type FixExtraRequiredFields<T> = T extends { properties: Record<string, any>; required: string[] }


### PR DESCRIPTION
## Description

This change fixes the issue #549 by slightly modifying the `FixMissingAdditionalProperties` type. It allows the `json` field to be strongly typed instead of being typed as `never` when using `post()` on a feTS client route.

It implements one of the fixes proposed by @nmss [here](https://github.com/ardatan/feTS/issues/549#issuecomment-1710177746)
I went for the solution that uses `Omit` since the other one adds a non-necessary `[x: string]: {}` (_it doesn't generate any errors though .._) to the `json` field (see screenshot)

![Capture d’écran de 2023-09-07 16-01-31](https://github.com/ardatan/feTS/assets/4068963/5ef3b9c5-4db4-47d3-8193-efd93da97472)


Related #549 

<!--
  Please do not use "Fixed" or "Resolves". Keep "Related" as-is.
-->

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots/Sandbox (if appropriate/relevant):

I created a repository that reproduces the issue (branch : `bug/post-json`) https://github.com/romaindurand/fets-test/tree/bug/post-json

## How Has This Been Tested?

It has only been tested on the reproduction repository.

**Test Environment**:

- OS: Ubuntu 20
- NodeJS: 18.15.0

## Checklist:

- [ ] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

The other alternative, as proposed by @nmss was to write the type as 
```typescript
type FixMissingAdditionalProperties<T> = T extends {
    type: 'object';
    additionalProperties: never;
} ? T & {
    additionalProperties: false;
} : T;
```
but as I said in the description, it generated a type bigger than needed in intellisense
