### PR TITLE
Fix SwaggerUI redirect url - use base path

### DIFF
--- a/packages/fets/src/createRouter.ts
+++ b/packages/fets/src/createRouter.ts
@@ -79,7 +79,7 @@ export function createRouterBase(
       return new fetchAPI.Response(null, {
         status: 302,
         headers: {
-          location: swaggerUI.endpoint,
+          location: `${basePath}${swaggerUI.endpoint}`,
         },
       });
     }


### PR DESCRIPTION
Router has wrong redirect to SwiggerUI '/docs' if basePath is used 

Fixes #654 
