### PR TITLE
reproduction: show broken types when defining responses

### DIFF
--- a/packages/fets/tests/zod-test.ts
+++ b/packages/fets/tests/zod-test.ts
@@ -13,6 +13,12 @@ const router = createRouter().route({
         }),
       }),
     },
+    responses: {
+      200: z.object({
+        id: z.number(),
+        title: z.string(),
+      }),
+    },
   },
   async handler(req) {
     const body = await req.json();


### PR DESCRIPTION
See https://github.com/ardatan/feTS/issues/675