### PR TITLE
Add headers optional parameter to createClient and remove typechecking on auth if there is a Authorization header

### DIFF
--- a/.changeset/curvy-sheep-report.md
+++ b/.changeset/curvy-sheep-report.md
@@ -1,0 +1,5 @@
+---
+'fets': patch
+---
+
+Make auth params optional if they are provided in the client options as `globalParams`

--- a/packages/fets/tests/client/apiKey-test.ts
+++ b/packages/fets/tests/client/apiKey-test.ts
@@ -1,7 +1,8 @@
 import { createClient, type NormalizeOAS } from '../../src';
 import type apiKeyExampleOas from './fixtures/example-apiKey-header-oas';
 
-const client = createClient<NormalizeOAS<typeof apiKeyExampleOas>>({});
+type NormalizedOAS = NormalizeOAS<typeof apiKeyExampleOas>;
+const client = createClient<NormalizedOAS>({});
 
 const res = await client['/me'].get({
   headers: {
@@ -15,3 +16,13 @@ if (!res.ok) {
 }
 const data = await res.json();
 console.info(`User ${data.id}: ${data.name}`);
+
+const clientWithPredefined = createClient<NormalizedOAS>({
+  globalParams: {
+    headers: {
+      'x-api-key': '123',
+    },
+  },
+});
+
+const res2 = await clientWithPredefined['/me'].get();

--- a/packages/fets/tests/client/global-params.spec.ts
+++ b/packages/fets/tests/client/global-params.spec.ts
@@ -1,0 +1,33 @@
+import { createClient, createRouter, Response } from 'fets';
+
+describe('Client Global Params', () => {
+  it('should pass global params', async () => {
+    const router = createRouter().route({
+      path: '/test',
+      method: 'GET',
+      handler: req =>
+        Response.json({
+          headers: Object.fromEntries(req.headers.entries()),
+          query: req.query,
+        }),
+    });
+    const client = createClient<typeof router>({
+      fetchFn: router.fetch,
+      globalParams: {
+        headers: {
+          'x-api-key': '123',
+        },
+        query: {
+          foo: 'bar',
+        },
+      },
+    });
+
+    const res = await client['/test'].get();
+
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.headers['x-api-key']).toBe('123');
+    expect(data.query['foo']).toBe('bar');
+  });
+});

--- a/website/src/pages/client/client-configuration.mdx
+++ b/website/src/pages/client/client-configuration.mdx
@@ -21,3 +21,20 @@ const client = createClient<typeof oas>({
   fetch: fetchH2 as typeof fetch
 })
 ```
+
+## Global Parameters
+
+You can also pass global parameters to the `createClient` function. These parameters will be passed
+to every request made by the client.
+
+```ts
+import { oas } from './oas'
+
+const client = createClient<typeof oas>({
+  globalParams: {
+    headers: {
+      Authorization: 'Bearer 123'
+    }
+  }
+})
+```

--- a/website/src/pages/client/plugins.mdx
+++ b/website/src/pages/client/plugins.mdx
@@ -16,41 +16,6 @@ A plugin in feTS is a function that returns an object with the following optiona
   - It enables you to modify the response or throw an error to prevent the response from being
     returned.
 
-### Custom Plugin example
-
-```ts
-import { ClientPlugin } from 'fets'
-
-export function myCustomPlugin(): ClientPlugin {
-  return {
-    onRequestInit({ requestInit }) {
-      requestInit.headers = {
-        ...requestInit.headers,
-        'X-Custom-Header': 'Custom value'
-      }
-    },
-    onFetch({ fetchFn, setFetchFn }) {
-      setFetchFn(async (input, init) => {
-        const response = await fetchFn(input, init)
-        if (response.status === 401) {
-          throw new Error('Unauthorized')
-        }
-        return response
-      })
-    },
-    onResponse({ response }) {
-      if (response.status === 401) {
-        throw new Error('Unauthorized')
-      }
-    }
-  }
-}
-
-const client = createClient<typeof someoas>({
-  plugins: [myCustomPlugin()]
-})
-```
-
 ## Handling Cookies With Built-in Cookies Plugin
 
 To handle cookies separately from the environment, you can use the `useCookieStore` plugin.


### PR DESCRIPTION
This is a solution for #413 and #399, it works like this:

```ts
const options = {
		endpoint: 'http://127.0.0.1:8080' as const,
		headers: {
			Authorization: 'foo',
		},
	}
	return createClient<NormalizeOAS<typeof openapi>, typeof options>(options)
```
This is more like a suggestion to the team than something to be directly merged, probably there is a TS trick to get rid of the second generic argument but I couldn't find it :(