### PR TITLE
Fix documentation of createRouter params

### DIFF
--- a/website/src/pages/server/openapi.mdx
+++ b/website/src/pages/server/openapi.mdx
@@ -62,15 +62,17 @@ These models will be presented as models in the OpenAPI specification.
 
 ```ts
 const router = createRouter({
-  components: {
-    schemas: {
-      // Define a model named User
-      User: {
-        type: 'object',
-        properties: {
-          id: { type: 'string' },
-          name: { type: 'string' },
-          email: { type: 'string' }
+  openAPI: {
+    components: {
+      schemas: {
+        // Define a model named User
+        User: {
+          type: 'object',
+          properties: {
+            id: { type: 'string' },
+            name: { type: 'string' },
+            email: { type: 'string' }
+          }
         }
       }
     }
@@ -125,11 +127,15 @@ const router = createRouter({
 ## Disabling OpenAPI
 
 For production, you may not want to expose the schema to the public. In this case, you can pass
-`false` to `swaggerUiEndpoint` and `oasEndpoint` options to disable them.
+`false` to `swaggerUI.endpoint` and `openAPI.endpoint` options to disable them.
 
 ```ts
 const router = createRouter({
-  swaggerUiEndpoint: false, // or process.env.NODE_ENV === 'production'
-  oasEndpoint: false
+  swaggerUI: {
+    endpoint: false // or process.env.NODE_ENV === 'production'
+  },
+  openAPI: {
+    endpoint: false
+  }
 })
 ```

--- a/website/src/pages/server/openapi.mdx
+++ b/website/src/pages/server/openapi.mdx
@@ -132,7 +132,7 @@ For production, you may not want to expose the schema to the public. In this cas
 ```ts
 const router = createRouter({
   swaggerUI: {
-    endpoint: false // or process.env.NODE_ENV === 'production'
+    endpoint: false // or process.env.NODE_ENV !== 'production'
   },
   openAPI: {
     endpoint: false


### PR DESCRIPTION
## Description

Fix outdated documentation of `createRouter` due to `swaggerUiEndpoint` and `oasEndpoint` being moved to a different place in the params.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

