### PR TITLE
Fix documentation referencing to old addRoute method

### DIFF
--- a/website/src/pages/server/type-safety-and-validation.mdx
+++ b/website/src/pages/server/type-safety-and-validation.mdx
@@ -124,7 +124,7 @@ define the schema:
 ```ts
 import { createRouter, Response } from "fets";
 
-const router = createRouter().addRoute({
+const router = createRouter().route({
   method: "GET",
   path: "/todos",
   // Define the request body schema
@@ -246,7 +246,7 @@ Example:
 ```ts
 import { createRouter, Response } from 'fets'
 
-const router = createRouter().addRoute({
+const router = createRouter().route({
   method: 'GET',
   path: '/todos',
   // Define the request body schema


### PR DESCRIPTION
## Description

Looks like `addRoute()` was a method before. I guess the current one is now `route()`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

