### PR TITLE
fix: support `exclusiveMinimum` & `exclusiveMaximum` boolean values

### DIFF
--- a/.changeset/rotten-parrots-draw.md
+++ b/.changeset/rotten-parrots-draw.md
@@ -1,0 +1,5 @@
+---
+'fets': patch
+---
+
+Support `exclusiveMinimum` or `exclusiveMaximum` as booleans instead of numbers only

--- a/packages/fets/src/client/types.ts
+++ b/packages/fets/src/client/types.ts
@@ -242,8 +242,10 @@ export type OASModel<
     : never;
 
 // Later suggest using json-machete
-export type FixJSONSchema<T> = FixAdditionalPropertiesForAllOf<
-  FixMissingAdditionalProperties<FixMissingTypeObject<FixExtraRequiredFields<T>>>
+export type FixJSONSchema<T> = RemoveExclusiveMinimumAndMaximum<
+  FixAdditionalPropertiesForAllOf<
+    FixMissingAdditionalProperties<FixMissingTypeObject<FixExtraRequiredFields<T>>>
+  >
 >;
 
 type FixAdditionalPropertiesForAllOf<T> = T extends { allOf: any[] }
@@ -268,6 +270,14 @@ type FixExtraRequiredFields<T> = T extends {
   ? Omit<T, 'required'> & {
       required: Call<Tuples.Filter<B.Extends<keyof T['properties']>>, T['required']>;
     }
+  : T;
+
+// Currently boolean values for those two are not supported
+type RemoveExclusiveMinimumAndMaximum<T> = T extends {
+  exclusiveMinimum?: boolean;
+  exclusiveMaximum?: boolean;
+}
+  ? Omit<T, 'exclusiveMinimum' | 'exclusiveMaximum'>
   : T;
 
 export type OASRequestParams<

--- a/packages/fets/tests/client/client-exclusive-oas.ts
+++ b/packages/fets/tests/client/client-exclusive-oas.ts
@@ -1,0 +1,15 @@
+import { createClient, NormalizeOAS } from 'fets';
+import exampleExclusiveOas from './fixtures/example-exclusive-oas';
+
+const client = createClient<NormalizeOAS<typeof exampleExclusiveOas>>({});
+
+const res = await client['/minmaxtest'].post({
+  json: {
+    sequence: 1,
+  },
+});
+
+if (res.ok) {
+  const successBody = await res.json();
+  console.log(successBody.sequence);
+}

--- a/packages/fets/tests/client/fixtures/example-exclusive-oas.ts
+++ b/packages/fets/tests/client/fixtures/example-exclusive-oas.ts
@@ -1,0 +1,63 @@
+export default {
+  openapi: '3.0.3',
+  info: {
+    title: 'Minmaxtest',
+    description: 'Minmaxtest',
+    version: '0.1.0',
+  },
+  components: {
+    securitySchemes: {
+      basicAuth: {
+        type: 'http',
+        scheme: 'basic',
+      },
+    },
+    schemas: {},
+  },
+  paths: {
+    '/minmaxtest': {
+      post: {
+        requestBody: {
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  sequence: {
+                    type: 'integer',
+                    exclusiveMinimum: true,
+                    minimum: 0,
+                  },
+                },
+                required: ['sequence'],
+                additionalProperties: false,
+              },
+            },
+          },
+          required: true,
+        },
+        responses: {
+          '201': {
+            description: 'Default Response',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    sequence: {
+                      type: 'integer',
+                      exclusiveMinimum: true,
+                      minimum: 0,
+                    },
+                  },
+                  required: ['sequence'],
+                  additionalProperties: false,
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+} as const;


### PR DESCRIPTION
Fixes #1203 