### PR TITLE
Solved typo in inferring types documentation

### DIFF
--- a/website/src/pages/client/inferring-schema-types.mdx
+++ b/website/src/pages/client/inferring-schema-types.mdx
@@ -19,7 +19,7 @@ type User = OASModel<NormalizeOAS<typeof oas>, 'User'>
 To infer request body parameters from an OpenAPI document, utilize the `OASRequestBody` type:
 
 ```ts filename="user-request-parameters.ts"
-import type { NormalizeOAS, OASRequestParameters } from 'fets'
+import type { NormalizeOAS, OASRequestParams } from 'fets'
 import type oas from './openapi'
 
 type AddUserInput = OASRequestParams<NormalizeOAS<typeof oas>, '/user', 'POST'>


### PR DESCRIPTION
## Description

Documentation error on Client/Inferring types:

https://the-guild.dev/openapi/fets/client/inferring-schema-types

Example:
```ts
import type { NormalizeOAS, OASRequestParameters } from 'fets'
import type oas from './openapi'
 
type AddUserInput = OASRequestParams<NormalizeOAS<typeof oas>, '/user', 'POST'>
```

Should be:
```ts
import type { NormalizeOAS, OASRequestParams} from 'fets'
import type oas from './openapi'
 
type AddUserInput = OASRequestParams<NormalizeOAS<typeof oas>, '/user', 'POST'>
```


Related #1784

<!--
  Please do not use "Fixed" or "Resolves". Keep "Related" as-is.
-->

## Type of change

Please delete options that are not relevant.

- [x] This change requires a documentation update

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
