### PR TITLE
Bump whatwg node server

### DIFF
--- a/.changeset/fets-3886-dependencies.md
+++ b/.changeset/fets-3886-dependencies.md
@@ -1,0 +1,5 @@
+---
+"fets": patch
+---
+dependencies updates:
+  - Updated dependency [`@whatwg-node/server@^0.11.0` ↗︎](https://www.npmjs.com/package/@whatwg-node/server/v/0.11.0) (from `^0.10.18`, in `dependencies`)

--- a/package-lock.json
+++ b/package-lock.json
@@ -9995,9 +9995,9 @@
       }
     },
     "node_modules/@whatwg-node/server": {
-      "version": "0.10.18",
-      "resolved": "https://registry.npmjs.org/@whatwg-node/server/-/server-0.10.18.tgz",
-      "integrity": "sha512-kMwLlxUbduttIgaPdSkmEarFpP+mSY8FEm+QWMBRJwxOHWkri+cxd8KZHO9EMrB9vgUuz+5WEaCawaL5wGVoXg==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/server/-/server-0.11.0.tgz",
+      "integrity": "sha512-VSdkwnJRr8Yv9UgB2aXB3VUPWwd6Oqnn0hycFwhg9pZgWxJXb7JmhsiXe9tmpMwjHFxli12PGcz9aI63YYloGQ==",
       "license": "MIT",
       "dependencies": {
         "@envelop/instrumentation": "^1.0.0",
@@ -29459,7 +29459,7 @@
         "@sinclair/typebox": "^0.34.48",
         "@whatwg-node/cookie-store": "^0.2.0",
         "@whatwg-node/fetch": "^0.10.12",
-        "@whatwg-node/server": "^0.10.18",
+        "@whatwg-node/server": "^0.11.0",
         "hotscript": "^1.0.11",
         "json-schema-to-ts": "^3.0.0",
         "qs": "^6.14.2",

--- a/packages/fets/package.json
+++ b/packages/fets/package.json
@@ -37,7 +37,7 @@
     "@sinclair/typebox": "^0.34.48",
     "@whatwg-node/cookie-store": "^0.2.0",
     "@whatwg-node/fetch": "^0.10.12",
-    "@whatwg-node/server": "^0.10.18",
+    "@whatwg-node/server": "^0.11.0",
     "hotscript": "^1.0.11",
     "json-schema-to-ts": "^3.0.0",
     "qs": "^6.14.2",


### PR DESCRIPTION
I bumped a minor with https://github.com/ardatan/whatwg-node/pull/3399, but whatwg node server uses zero-based versioning making this a breaking change - even though it's not.