### PR TITLE
fix: make anonymous security alternatives optional

### DIFF
--- a/packages/fets/src/client/types.ts
+++ b/packages/fets/src/client/types.ts
@@ -682,15 +682,17 @@ export type SecuritySchemeName<T extends { security: { [key: string]: any }[] }>
 >[number];
 
 type HasAnonymousSecurityAlternative<T extends { security: { [key: string]: any }[] }> =
-  true extends (T['security'][number] extends infer TRequirement
-    ? TRequirement extends unknown
-      ? keyof TRequirement extends never
-        ? true
+  true extends (
+    T['security'][number] extends infer TRequirement
+      ? TRequirement extends unknown
+        ? keyof TRequirement extends never
+          ? true
+          : false
         : false
       : false
-    : false)
-  ? true
-  : false;
+  )
+    ? true
+    : false;
 
 export type OASSecurityParams<TSecurityScheme> = BasicAuthParams<TSecurityScheme> &
   BearerAuthParams<TSecurityScheme> &
@@ -738,7 +740,7 @@ type OASSecurityParamsBySecurityRefBase<TOAS, TSecurityObj> = TSecurityObj exten
           ? OAuth2AuthParams<{
               type: 'oauth2';
             }>
-        : {}
+          : {}
   : {};
 
 export type OASSecurityParamsBySecurityRef<TOAS, TSecurityObj> = TSecurityObj extends {

--- a/packages/fets/src/client/types.ts
+++ b/packages/fets/src/client/types.ts
@@ -681,12 +681,23 @@ export type SecuritySchemeName<T extends { security: { [key: string]: any }[] }>
   T['security']
 >[number];
 
+type HasAnonymousSecurityAlternative<T extends { security: { [key: string]: any }[] }> =
+  true extends (T['security'][number] extends infer TRequirement
+    ? TRequirement extends unknown
+      ? keyof TRequirement extends never
+        ? true
+        : false
+      : false
+    : false)
+  ? true
+  : false;
+
 export type OASSecurityParams<TSecurityScheme> = BasicAuthParams<TSecurityScheme> &
   BearerAuthParams<TSecurityScheme> &
   ApiKeyAuthParams<TSecurityScheme> &
   OAuth2AuthParams<TSecurityScheme>;
 
-export type OASSecurityParamsBySecurityRef<TOAS, TSecurityObj> = TSecurityObj extends {
+type OASSecurityParamsBySecurityRefBase<TOAS, TSecurityObj> = TSecurityObj extends {
   security: { [key: string]: any }[];
 }
   ? TOAS extends
@@ -727,5 +738,13 @@ export type OASSecurityParamsBySecurityRef<TOAS, TSecurityObj> = TSecurityObj ex
           ? OAuth2AuthParams<{
               type: 'oauth2';
             }>
-          : {}
+        : {}
+  : {};
+
+export type OASSecurityParamsBySecurityRef<TOAS, TSecurityObj> = TSecurityObj extends {
+  security: { [key: string]: any }[];
+}
+  ? HasAnonymousSecurityAlternative<TSecurityObj> extends true
+    ? DeepPartial<OASSecurityParamsBySecurityRefBase<TOAS, TSecurityObj>>
+    : OASSecurityParamsBySecurityRefBase<TOAS, TSecurityObj>
   : {};

--- a/packages/fets/tests/client/apiKey-test.ts
+++ b/packages/fets/tests/client/apiKey-test.ts
@@ -17,6 +17,8 @@ if (!res.ok) {
 const data = await res.json();
 console.info(`User ${data.id}: ${data.name}`);
 
+await client['/me'].get();
+
 const clientWithPredefined = createClient<NormalizedOAS>({
   globalParams: {
     headers: {

--- a/packages/fets/tests/client/fixtures/example-apiKey-header-oas.ts
+++ b/packages/fets/tests/client/fixtures/example-apiKey-header-oas.ts
@@ -38,6 +38,7 @@ export default {
       get: {
         operationId: 'getMe',
         security: [
+          {},
           {
             apiKey: [],
           },


### PR DESCRIPTION
Summary
- Detect empty security requirements in client auth types.
- Make auth params partial when an operation allows anonymous access beside API key auth.
- Add API key fixture coverage for optional security.

Validation
- Diff whitespace check passed.
- Full TypeScript test run blocked locally because the machine has 1.9 GiB free and npm install failed with ENOSPC before dependencies finished installing.