### PR TITLE
chore(gitignore): ignore common OS/editor metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,22 @@ junit.xml
 yarn.lock
 
 eslint_report.json
+
+# OS metadata
+.DS_Store
+._*
+.Spotlight-V100
+.Trashes
+.AppleDouble
+Thumbs.db
+ehthumbs.db
+ehthumbs_vista.db
+Desktop.ini
+$RECYCLE.BIN/
+*.lnk
+
+# Editor / IDE
+.idea/
+.vscode/
+*.swp
+*.swo


### PR DESCRIPTION
Small `.gitignore` cleanup: adds standard OS metadata files (`.DS_Store`, `Thumbs.db`, `Desktop.ini`) and editor project folders (`.idea/`, `.vscode/`) that aren't currently listed.

No effect on tracked files â€” this only prevents new accidental commits.