### PR TITLE
Format the TypeBox code shown on website properly

### DIFF
--- a/website/src/pages/server/programmatic-schemas.mdx
+++ b/website/src/pages/server/programmatic-schemas.mdx
@@ -12,12 +12,22 @@ Instead of using JSON Schemas, you have the option to define your schemas using
 ```typescript
 import { createRouter, Response, Type } from 'fets'
 
-const router = createRouter().route({ path: '/user/:id', method: 'POST', schemas: { request: {
-headers: Type.Object({ authorization: Type.String().regex(/Bearer .+/) }), params: Type.Object({ id:
-Type.String({ format: 'uuid' }) }) } }, // Response type will be automatically inferred from the
-handler's return type handler: request => { if (request.params.id !== EXPECTED_UUID) { return
-Response.json( { message: 'User not found' }, { status: 404 } ) } return Response.json({ id:
-request.params.id, name: 'John Doe' }) } })
+const router = createRouter().route({
+  path: '/user/:id',
+  method: 'POST',
+  schemas: {
+    request: {
+      headers: Type.Object({ authorization: Type.String().regex(/Bearer .+/) }),
+      params: Type.Object({ id: Type.String({ format: 'uuid' }) })
+    },
+  }, // Response type will be automatically inferred from the handler's return type
+  handler: (request) => {
+    if (request.params.id !== EXPECTED_UUID) {
+      return Response.json({ message: 'User not found' }, { status: 404 })
+    }
+    return Response.json({ id: request.params.id, name: 'John Doe' })
+  }
+})
 
 ````
 </Tabs.Tab>


### PR DESCRIPTION
TypeBox router example was reformatted without changing its behavior.