### PR TITLE
fix: pin Swagger UI CDN assets with SRI

### DIFF
--- a/.changeset/swagger-ui-sri.md
+++ b/.changeset/swagger-ui-sri.md
@@ -1,0 +1,7 @@
+---
+'fets': patch
+---
+
+Pin Swagger UI CDN assets and load them with Subresource Integrity (SRI)
+
+Swagger UI previously pulled unversioned `unpkg.com/swagger-ui-dist` scripts/styles without integrity checks. Assets are now pinned to `swagger-ui-dist@5.11.0` (and the dark theme CSS) and loaded via `<link>`/`<script>` tags with `integrity` + `crossorigin`, so a compromised CDN cannot silently swap the payload.

--- a/packages/fets/src/swagger-ui.html
+++ b/packages/fets/src/swagger-ui.html
@@ -5,12 +5,21 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="description" content="SwaggerUI" />
     <title>SwaggerUI</title>
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/gh/Itz-fork/Fastapi-Swagger-UI-Dark/assets/swagger_ui_dark.min.css"
+      media="(prefers-color-scheme: dark)"
+      crossorigin="anonymous"
+      integrity="sha384-uFFUYDzMQNCAsNQHyjX9WExpaDBrtT+3F/7yo37l/lUEsOa7yAUqDFRlDEG2u8RY"
+    />
+    <link
+      rel="stylesheet"
+      href="https://unpkg.com/swagger-ui-dist@5.11.0/swagger-ui.css"
+      media="(prefers-color-scheme: light)"
+      crossorigin="anonymous"
+      integrity="sha384-+yyzNgM3K92sROwsXxYCxaiLWxWJ0G+v/9A+qIZ2rgefKgkdcmJI+L601cqPD/Ut"
+    />
     <style>
-      @import 'https://cdn.jsdelivr.net/gh/Itz-fork/Fastapi-Swagger-UI-Dark/assets/swagger_ui_dark.min.css'
-        (prefers-color-scheme: dark);
-
-      @import 'https://unpkg.com/swagger-ui-dist/swagger-ui.css' (prefers-color-scheme: light);
-
       @media (prefers-color-scheme: dark) {
         .swagger-ui textarea {
           background: hsl(358.8deg 1.05% 1.91% / 80%) !important;
@@ -42,7 +51,11 @@
 
   <body>
     <div id="swagger-ui"></div>
-    <script src="https://unpkg.com/swagger-ui-dist/swagger-ui-bundle.js" crossorigin></script>
+    <script
+      src="https://unpkg.com/swagger-ui-dist@5.11.0/swagger-ui-bundle.js"
+      crossorigin="anonymous"
+      integrity="sha384-qn5tagrAjZi8cSmvZ+k3zk4+eDEEUcP9myuR2J6V+/H6rne++v6ChO7EeHAEzqxQ"
+    ></script>
     <script>
       window.onload = () => {
         window.ui = SwaggerUIBundle(__SWAGGER_UI_OPTIONS__);


### PR DESCRIPTION
## Summary
- Pin `swagger-ui-dist` to `5.11.0` and load CSS/JS with real Subresource Integrity hashes
- Switch stylesheets from `@import` to `<link>` so `integrity` is enforceable
- Also cover the dark-theme CSS CDN asset

Supersedes #3807 (that PR pinned the version but used a placeholder `integrity` value that would break Swagger UI in browsers).

## Test plan
- [x] Downloaded each CDN URL and verified `sha384` digests match the HTML attributes
- [x] CI green