### PR TITLE
fix: pin Swagger UI dark theme CSS to a commit SHA

### DIFF
--- a/.changeset/pin-swagger-dark-theme.md
+++ b/.changeset/pin-swagger-dark-theme.md
@@ -1,0 +1,7 @@
+---
+'fets': patch
+---
+
+Pin the Swagger UI dark-theme CSS to an immutable jsDelivr GitHub commit
+
+The dark stylesheet is loaded from `cdn.jsdelivr.net/gh/Itz-fork/Fastapi-Swagger-UI-Dark@868ea5da…` with SRI, so upstream default-branch changes cannot invalidate the integrity hash or swap the file silently.

--- a/.changeset/swagger-ui-sri.md
+++ b/.changeset/swagger-ui-sri.md
@@ -4,4 +4,4 @@
 
 Pin Swagger UI CDN assets and load them with Subresource Integrity (SRI)
 
-Swagger UI previously pulled unversioned `unpkg.com/swagger-ui-dist` scripts/styles without integrity checks. Assets are now pinned to `swagger-ui-dist@5.11.0` (and the dark theme CSS) and loaded via `<link>`/`<script>` tags with `integrity` + `crossorigin`, so a compromised CDN cannot silently swap the payload.
+Swagger UI previously pulled unversioned `unpkg.com/swagger-ui-dist` scripts/styles without integrity checks. Assets are now pinned to `swagger-ui-dist@5.11.0` and loaded via `<link>`/`<script>` tags with `integrity` + `crossorigin`, so a compromised CDN cannot silently swap the payload.

--- a/packages/fets/src/swagger-ui.html
+++ b/packages/fets/src/swagger-ui.html
@@ -7,7 +7,7 @@
     <title>SwaggerUI</title>
     <link
       rel="stylesheet"
-      href="https://cdn.jsdelivr.net/gh/Itz-fork/Fastapi-Swagger-UI-Dark/assets/swagger_ui_dark.min.css"
+      href="https://cdn.jsdelivr.net/gh/Itz-fork/Fastapi-Swagger-UI-Dark@868ea5da89b4e7d9aa7fe57f601485d68f26695d/assets/swagger_ui_dark.min.css"
       media="(prefers-color-scheme: dark)"
       crossorigin="anonymous"
       integrity="sha384-uFFUYDzMQNCAsNQHyjX9WExpaDBrtT+3F/7yo37l/lUEsOa7yAUqDFRlDEG2u8RY"


### PR DESCRIPTION
## Summary
- Pin the dark-theme stylesheet to jsDelivr `gh/...@868ea5da…` (immutable commit)
- Keep the existing SRI hash (content unchanged)
- Clarify the earlier changeset wording

Follow-up for Copilot review comments on #4082.

## Test plan
- [x] Fetched the commit-pinned URL and verified `sha384` matches the HTML attribute
- [ ] CI green