### PR TITLE
fix: keep precise types for OpenAPI 3.0 nullable $ref

### DIFF
--- a/.changeset/fix-nullable-oneof-ref.md
+++ b/.changeset/fix-nullable-oneof-ref.md
@@ -1,0 +1,9 @@
+---
+'fets': patch
+---
+
+Stop treating OpenAPI 3.0 nullable `$ref`s (`nullable: true, oneOf: [{ $ref }]`) as circular schemas
+
+`HasCircularAnyOfRef` used any `$id` on an `anyOf`/`oneOf` member as a cycle signal, but `NormalizeOAS` stamps `$id` onto every resolved `$ref`. Non-recursive schemas then fell through to `DirectType`, which dropped `| null` and `additionalProperties`.
+
+Cycle detection now requires the expanded `$ref` to actually be the enclosing schema (or a nested self-reference like `RequestBody → FilterGroup → FilterGroup`). `DirectType` also maps `nullable` and `additionalProperties` for schemas that are genuinely recursive.

--- a/packages/fets/src/types.ts
+++ b/packages/fets/src/types.ts
@@ -189,43 +189,81 @@ export type ArrayItemValue<TJSONSchema extends JSONSchema> = TJSONSchema extends
 // Circular anyOf/oneOf detection
 // ---------------------------------------------------------------------------
 
-// Detects whether any property of a schema contains anyOf/oneOf array items
-// that carry the $id marker injected by ResolveRef (i.e. they are $ref-expanded
-// schemas).  Such schemas cannot be processed by json-schema-to-ts's
-// ParseObjectSchema without triggering TS2615 ("Type of property X circularly
-// references itself in mapped type"), because MergeSubSchema produces anonymous
-// types that share the same `properties` object as the original schema.
-// When this helper returns `true`, FromSchema uses DirectType instead.
+// Detects a *real* cycle through anyOf/oneOf $ref members (after NormalizeOAS
+// stamps `$id` onto every resolved `$ref`).
+//
+// json-schema-to-ts's ParseObjectSchema / MergeSubSchema cannot process a
+// schema that anyOf/oneOf's back to itself (TS2615). The OpenAPI 3.0 nullable
+// `$ref` idiom `{ nullable: true, oneOf: [{ $ref }] }` also produces `$id`
+// markers, but is not circular — those must keep using json-schema-to-ts so
+// `nullable` and `additionalProperties` stay precise.
+//
+// A member is treated as circular only when:
+//   1. the expanded `$ref` is the enclosing schema (self-reference), or
+//   2. the expanded `$ref` itself anyOf/oneOf's back to *that* schema
+//      (e.g. RequestBody → FilterGroup → FilterGroup).
 type HasCircularAnyOfRef<T extends JSONSchema> = T extends {
   properties: Record<string, JSONSchema>;
 }
-  ? {
-      [K in keyof T['properties']]: ContainsAnyOfWithId<T['properties'][K]>;
-    }[keyof T['properties']] extends false
-    ? false
-    : true
+  ? true extends {
+      [K in keyof T['properties']]: PropIntroducesCycle<T['properties'][K], T>;
+    }[keyof T['properties']]
+    ? true
+    : false
   : false;
 
-// Checks whether a schema (or its `items` descendant) has an anyOf/oneOf
-// whose items include at least one schema with an $id marker.
-type ContainsAnyOfWithId<T> = T extends {
+type PropIntroducesCycle<S, Root> = S extends {
   anyOf: infer Items extends readonly JSONSchema[];
 }
-  ? AnyHasId<Items>
-  : T extends { oneOf: infer Items extends readonly JSONSchema[] }
-    ? AnyHasId<Items>
-    : T extends { items: infer I extends JSONSchema }
-      ? ContainsAnyOfWithId<I>
+  ? TupleIntroducesCycle<Items, Root>
+  : S extends { oneOf: infer Items extends readonly JSONSchema[] }
+    ? TupleIntroducesCycle<Items, Root>
+    : S extends { items: infer I extends JSONSchema }
+      ? PropIntroducesCycle<I, Root>
       : false;
 
-// Returns `true` if any element of the tuple has an $id property.
-type AnyHasId<Items extends readonly JSONSchema[]> = Items extends readonly [
+type TupleIntroducesCycle<Items extends readonly JSONSchema[], Root> = Items extends readonly [
   infer Head extends JSONSchema,
   ...infer Tail extends readonly JSONSchema[],
 ]
-  ? Head extends { $id: string }
+  ? MemberIntroducesCycle<Head, Root> extends true
     ? true
-    : AnyHasId<Tail>
+    : TupleIntroducesCycle<Tail, Root>
+  : false;
+
+// `$id` is extra on resolved refs, so `{ $id } & Root` still extends Root.
+type MemberIntroducesCycle<Item, Root> = Item extends { $id: string }
+  ? [Item] extends [Root]
+    ? true
+    : HasSelfCircularAnyOf<Item>
+  : false;
+
+// One extra level: does this schema anyOf/oneOf back to itself?
+type HasSelfCircularAnyOf<T> = T extends { properties: Record<string, JSONSchema> }
+  ? true extends {
+      [K in keyof T['properties']]: DirectSelfAnyOf<T['properties'][K], T>;
+    }[keyof T['properties']]
+    ? true
+    : false
+  : false;
+
+type DirectSelfAnyOf<S, Root> = S extends {
+  anyOf: infer Items extends readonly JSONSchema[];
+}
+  ? TupleHasSelf<Items, Root>
+  : S extends { oneOf: infer Items extends readonly JSONSchema[] }
+    ? TupleHasSelf<Items, Root>
+    : S extends { items: infer I extends JSONSchema }
+      ? DirectSelfAnyOf<I, Root>
+      : false;
+
+type TupleHasSelf<Items extends readonly JSONSchema[], Root> = Items extends readonly [
+  infer Head extends JSONSchema,
+  ...infer Tail extends readonly JSONSchema[],
+]
+  ? [Head] extends [Root]
+    ? true
+    : TupleHasSelf<Tail, Root>
   : false;
 
 // ---------------------------------------------------------------------------
@@ -248,7 +286,11 @@ type AnyHasId<Items extends readonly JSONSchema[]> = Items extends readonly [
 // type alias, so the compiler can no longer detect the cycle and raises TS2615.
 // DirectType avoids this entirely by keeping every recursive reference as the
 // same named type alias instantiation.
-export type DirectType<T extends JSONSchema> = T extends { static: infer U }
+export type DirectType<T extends JSONSchema> = T extends { nullable: true }
+  ? DirectTypeValue<T> | null
+  : DirectTypeValue<T>;
+
+type DirectTypeValue<T extends JSONSchema> = T extends { static: infer U }
   ? U
   : T extends { anyOf: infer Items extends readonly JSONSchema[] }
     ? DirectUnionType<Items>
@@ -287,9 +329,20 @@ export type DirectType<T extends JSONSchema> = T extends { static: infer U }
                                 properties: infer Props extends Record<string, JSONSchema>;
                               }
                             ? { [K in keyof Props]?: DirectType<Props[K]> }
-                            : T extends { type: 'object' }
-                              ? Record<string, unknown>
-                              : unknown;
+                            : T extends {
+                                  type: 'object';
+                                  additionalProperties: infer AP;
+                                }
+                              ? AP extends false
+                                ? Record<string, never>
+                                : AP extends true
+                                  ? Record<string, unknown>
+                                  : AP extends JSONSchema
+                                    ? Record<string, DirectType<AP>>
+                                    : Record<string, unknown>
+                              : T extends { type: 'object' }
+                                ? Record<string, unknown>
+                                : unknown;
 
 type DirectUnionType<Items extends readonly JSONSchema[]> = Items extends readonly [
   infer Head extends JSONSchema,

--- a/packages/fets/src/types.ts
+++ b/packages/fets/src/types.ts
@@ -220,7 +220,24 @@ type PropIntroducesCycle<S, Root> = S extends {
     ? TupleIntroducesCycle<Items, Root>
     : S extends { items: infer I extends JSONSchema }
       ? PropIntroducesCycle<I, Root>
-      : false;
+      : // Resolved $refs carry `$id` plus the target schema body. Walking that
+        // body re-enters the same properties map and trips TS2615. Inline
+        // wrappers (no `$id`) still need to be traversed.
+        S extends { $id: string }
+        ? false
+        : S extends { properties: infer P extends Record<string, JSONSchema> }
+          ? true extends {
+              [K in keyof P]: PropIntroducesCycle<P[K], Root>;
+            }[keyof P]
+            ? true
+            : AdditionalPropertiesCycle<S, Root>
+          : AdditionalPropertiesCycle<S, Root>;
+
+type AdditionalPropertiesCycle<S, Root> = S extends {
+  additionalProperties: infer AP extends JSONSchema;
+}
+  ? PropIntroducesCycle<AP, Root>
+  : false;
 
 type TupleIntroducesCycle<Items extends readonly JSONSchema[], Root> = Items extends readonly [
   infer Head extends JSONSchema,
@@ -255,7 +272,21 @@ type DirectSelfAnyOf<S, Root> = S extends {
     ? TupleHasSelf<Items, Root>
     : S extends { items: infer I extends JSONSchema }
       ? DirectSelfAnyOf<I, Root>
-      : false;
+      : S extends { $id: string }
+        ? false
+        : S extends { properties: infer P extends Record<string, JSONSchema> }
+          ? true extends {
+              [K in keyof P]: DirectSelfAnyOf<P[K], Root>;
+            }[keyof P]
+            ? true
+            : AdditionalPropertiesSelf<S, Root>
+          : AdditionalPropertiesSelf<S, Root>;
+
+type AdditionalPropertiesSelf<S, Root> = S extends {
+  additionalProperties: infer AP extends JSONSchema;
+}
+  ? DirectSelfAnyOf<AP, Root>
+  : false;
 
 type TupleHasSelf<Items extends readonly JSONSchema[], Root> = Items extends readonly [
   infer Head extends JSONSchema,
@@ -318,31 +349,55 @@ type DirectTypeValue<T extends JSONSchema> = T extends { static: infer U }
                               type: 'object';
                               properties: infer Props extends Record<string, JSONSchema>;
                               required: infer Req extends readonly string[];
+                              additionalProperties: infer AP;
                             }
-                          ? {
-                              [K in Extract<keyof Props, Req[number]>]: DirectType<Props[K]>;
-                            } & {
-                              [K in Exclude<keyof Props, Req[number]>]?: DirectType<Props[K]>;
-                            }
+                          ? DirectNamedProps<Props, Req> & DirectIndexSignature<AP>
                           : T extends {
                                 type: 'object';
                                 properties: infer Props extends Record<string, JSONSchema>;
+                                additionalProperties: infer AP;
                               }
-                            ? { [K in keyof Props]?: DirectType<Props[K]> }
+                            ? DirectNamedProps<Props> & DirectIndexSignature<AP>
                             : T extends {
                                   type: 'object';
-                                  additionalProperties: infer AP;
+                                  properties: infer Props extends Record<string, JSONSchema>;
+                                  required: infer Req extends readonly string[];
                                 }
-                              ? AP extends false
-                                ? Record<string, never>
-                                : AP extends true
-                                  ? Record<string, unknown>
-                                  : AP extends JSONSchema
-                                    ? Record<string, DirectType<AP>>
-                                    : Record<string, unknown>
-                              : T extends { type: 'object' }
-                                ? Record<string, unknown>
-                                : unknown;
+                              ? DirectNamedProps<Props, Req>
+                              : T extends {
+                                    type: 'object';
+                                    properties: infer Props extends Record<string, JSONSchema>;
+                                  }
+                                ? DirectNamedProps<Props>
+                                : T extends {
+                                      type: 'object';
+                                      additionalProperties: infer AP;
+                                    }
+                                  ? AP extends false
+                                    ? Record<string, never>
+                                    : DirectIndexSignature<AP>
+                                  : T extends { type: 'object' }
+                                    ? Record<string, unknown>
+                                    : unknown;
+
+type DirectNamedProps<
+  Props extends Record<string, JSONSchema>,
+  Req extends readonly string[] | undefined = undefined,
+> = [Req] extends [readonly string[]]
+  ? {
+      [K in Extract<keyof Props, Req[number]>]: DirectType<Props[K]>;
+    } & {
+      [K in Exclude<keyof Props, Req[number]>]?: DirectType<Props[K]>;
+    }
+  : { [K in keyof Props]?: DirectType<Props[K]> };
+
+type DirectIndexSignature<AP> = AP extends false
+  ? unknown
+  : AP extends true
+    ? Record<string, unknown>
+    : AP extends JSONSchema
+      ? Record<string, DirectType<AP>>
+      : Record<string, unknown>;
 
 type DirectUnionType<Items extends readonly JSONSchema[]> = Items extends readonly [
   infer Head extends JSONSchema,

--- a/packages/fets/tests/client/nullable-oneof-ref-test.ts
+++ b/packages/fets/tests/client/nullable-oneof-ref-test.ts
@@ -1,4 +1,4 @@
-import { OASModel, type NormalizeOAS } from 'fets';
+import { OASModel, type DirectType, type NormalizeOAS } from 'fets';
 
 // OpenAPI 3.0 nullable $ref idiom. NormalizeOAS stamps `$id` onto the resolved
 // Address, but Stage is not recursive — FromSchema must not fall back to DirectType.
@@ -52,3 +52,54 @@ if (address) {
 
 // @ts-expect-error note is string | null | undefined, not number
 stage.note = 1;
+
+// Self-reference nested under an object property (not a direct anyOf/oneOf on Root).
+const nestedSpec = {
+  openapi: '3.0.0',
+  info: { title: 't', version: '1' },
+  paths: {},
+  components: {
+    schemas: {
+      Root: {
+        type: 'object',
+        properties: {
+          wrapper: {
+            type: 'object',
+            properties: {
+              node: {
+                oneOf: [{ $ref: '#/components/schemas/Root' }, { type: 'string' }],
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+} as const;
+
+type NestedRoot = OASModel<NormalizeOAS<typeof nestedSpec>, 'Root'>;
+declare const nestedRoot: NestedRoot;
+const nestedNode: NestedRoot | string | undefined = nestedRoot.wrapper?.node;
+void nestedNode;
+if (typeof nestedRoot.wrapper?.node !== 'string' && nestedRoot.wrapper?.node) {
+  const again: NestedRoot | string | undefined = nestedRoot.wrapper.node.wrapper?.node;
+  void again;
+}
+
+// DirectType is used without NormalizeOAS, which would rewrite additionalProperties to false.
+type Combined = {
+  type: 'object';
+  properties: {
+    name: { type: 'string' };
+    nested: { anyOf: readonly [Combined, { type: 'string' }] };
+  };
+  additionalProperties: { type: 'string' };
+};
+type CombinedResult = DirectType<Combined>;
+declare const combined: CombinedResult;
+const named: string | undefined = combined.name;
+const extra: string = combined.extra;
+void named;
+void extra;
+const nestedUnion: CombinedResult | string | undefined = combined.nested;
+void nestedUnion;

--- a/packages/fets/tests/client/nullable-oneof-ref-test.ts
+++ b/packages/fets/tests/client/nullable-oneof-ref-test.ts
@@ -1,0 +1,54 @@
+import { OASModel, type NormalizeOAS } from 'fets';
+
+// OpenAPI 3.0 nullable $ref idiom. NormalizeOAS stamps `$id` onto the resolved
+// Address, but Stage is not recursive — FromSchema must not fall back to DirectType.
+// See: https://github.com/ardatan/feTS/issues/4104
+const spec = {
+  openapi: '3.0.0',
+  info: { title: 't', version: '1' },
+  paths: {},
+  components: {
+    schemas: {
+      Address: {
+        type: 'object',
+        properties: {
+          line1: { type: 'string' },
+          tags: { type: 'object', additionalProperties: { type: 'string' } },
+        },
+        required: ['line1'],
+      },
+      Stage: {
+        type: 'object',
+        properties: {
+          address: { nullable: true, oneOf: [{ $ref: '#/components/schemas/Address' }] },
+          note: { type: 'string', nullable: true },
+        },
+        required: [],
+      },
+    },
+  },
+} as const;
+
+type NormalizedOAS = NormalizeOAS<typeof spec>;
+type Stage = OASModel<NormalizedOAS, 'Stage'>;
+
+declare const stage: Stage;
+
+const address: { line1: string; tags?: Record<string, string> } | null | undefined = stage.address;
+const note: string | null | undefined = stage.note;
+void address;
+void note;
+
+stage.address = null;
+stage.note = null;
+
+if (address) {
+  const tags: Record<string, string> | undefined = address.tags;
+  void tags;
+  // @ts-expect-error tags values are strings
+  const _badTags: Record<string, number> | undefined = address.tags;
+  void _badTags;
+}
+
+// @ts-expect-error note is string | null | undefined, not number
+stage.note = 1;


### PR DESCRIPTION
## Summary
- Fixes [#4104](https://github.com/ardatan/feTS/issues/4104): `HasCircularAnyOfRef` treated every `$id` on `anyOf`/`oneOf` as a cycle, but `NormalizeOAS` stamps `$id` onto every resolved `$ref`.
- OpenAPI 3.0 `nullable: true, oneOf: [{ $ref }]` is not recursive; it no longer falls through to `DirectType`, so `| null` and `additionalProperties` are preserved.
- `DirectType` still handles genuine recursive unions, and now maps `nullable` / `additionalProperties` when it is used.

## Test plan
- [x] `tsc --noEmit` includes the new `nullable-oneof-ref-test.ts` (address `| null`, note `| null`, tags `Record<string, string>`)
- [x] Existing circular `anyOf` / mutual `$ref` type tests still type-check
- [ ] CI type-check / unit jobs green