### PR TITLE
Bump @xmldom/xmldom to 0.9.12 [security]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10447,9 +10447,9 @@
       }
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.9.10",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
-      "integrity": "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==",
+      "version": "0.9.12",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.12.tgz",
+      "integrity": "sha512-5AXjrcMClTryPe9LgZrygpB1lj7s0S9E0+W+AHaVKAVyHanafK86iPSvG5xHVSp/jC+VH1UXu0TAEmY279xH7A==",
       "license": "MIT",
       "engines": {
         "node": ">=14.6"

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
   },
   "overrides": {
     "@pulumi/pulumi": "3.260.0",
+    "@xmldom/xmldom": "0.9.12",
     "braces": "3.0.3",
     "cookie": "2.0.1",
     "diff": "9.0.0",


### PR DESCRIPTION
## Summary
- Resolves [Dependabot alert #234](https://github.com/ardatan/feTS/security/dependabot/234) ([CVE-2026-83610](https://github.com/advisories/GHSA-6gmq-8vp8-gcm6) / GHSA-6gmq-8vp8-gcm6)
- Pins `@xmldom/xmldom` to `0.9.12` via root `overrides` (transitive from `speech-rule-engine` → MathJax / Nextra / website)

## Test plan
- [ ] Confirm `npm ls @xmldom/xmldom` reports `0.9.12`
- [ ] Confirm Dependabot alert #234 auto-closes after merge